### PR TITLE
Gregfing the recipe

### DIFF
--- a/src/main/java/com/technicianlp/chestgrate/Main.java
+++ b/src/main/java/com/technicianlp/chestgrate/Main.java
@@ -1,5 +1,6 @@
 package com.technicianlp.chestgrate;
 
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
 import cpw.mods.fml.common.Mod;
@@ -39,15 +40,18 @@ public class Main {
         ShapedArcaneRecipe recipe = ThaumcraftApi.addArcaneCraftingRecipe(
             "ALCHGRATE",
             new ItemStack(this.block, 1),
-            new AspectList().add(Aspect.ORDER, 50)
-                .add(Aspect.ENTROPY, 50),
-            "VGV",
+            new AspectList().add(Aspect.ORDER, 25)
+                .add(Aspect.ENTROPY, 25)
+                .add(Aspect.EARTH, 25),
+            "TGT",
             "VSV",
-            "VCV",
+            "TCT",
             'V',
-            new ItemStack(ConfigItems.itemResource, 1, 16),
+            "plateVoid",
+            'T',
+            "screwThaumium",
             'G',
-            new ItemStack(ConfigBlocks.blockMetalDevice, 1, 5),
+            new ItemStack((Item) Item.itemRegistry.getObject("Botania:openCrate")),
             'S',
             new ItemStack(ConfigItems.itemShard, 1, 6),
             'C',

--- a/src/main/java/com/technicianlp/chestgrate/Main.java
+++ b/src/main/java/com/technicianlp/chestgrate/Main.java
@@ -40,8 +40,8 @@ public class Main {
         ShapedArcaneRecipe recipe = ThaumcraftApi.addArcaneCraftingRecipe(
             "ALCHGRATE",
             new ItemStack(this.block, 1),
-            new AspectList().add(Aspect.ORDER, 25)
-                .add(Aspect.ENTROPY, 25)
+            new AspectList().add(Aspect.ORDER, 50)
+                .add(Aspect.ENTROPY, 50)
                 .add(Aspect.EARTH, 25),
             "TGT",
             "VSV",


### PR DESCRIPTION
Change from this:
![image](https://github.com/GTNewHorizons/AlchemyGrate/assets/45178400/a7bb1b83-6d42-42ee-a605-54d283a789a0)

To this:
![image](https://github.com/GTNewHorizons/AlchemyGrate/assets/45178400/25685c1d-a2f8-4996-8cfe-121c407f828f)

Why this changes?

- Change the ingots to plates, and thaumium screws, needing lees void metal
- Change the grate to a crate since the grate is already used in the recipe of the hungry chest, and in current setups of the Advanced Alchemical Furnace players usually use open crates, so its the upgrade